### PR TITLE
I've made some changes to address the issues you reported from `npm r…

### DIFF
--- a/my-sveltekit-app/jsconfig.json
+++ b/my-sveltekit-app/jsconfig.json
@@ -1,11 +1,11 @@
 {
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "$lib": ["src/lib"],
-      "$lib/*": ["src/lib/*"]
-    },
+    // "baseUrl": ".", // REMOVED
+    // "paths": { // REMOVED
+    //   "$lib": ["src/lib"], // REMOVED
+    //   "$lib/*": ["src/lib/*"] // REMOVED
+    // }, // REMOVED
     "checkJs": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/my-sveltekit-app/src/lib/components/Sidebar.svelte
+++ b/my-sveltekit-app/src/lib/components/Sidebar.svelte
@@ -18,13 +18,12 @@
     deleteChat
   } from '$lib/stores/chatStore.js';
 
-
   import {
     uploadedFiles,
     uploadFile,
     deleteFile as deleteUploadedFile, // Renamed to avoid conflict if any
     isUploading as isFileUploading,
-    uploadError: fileUploadError,
+    fileUploadError, // Corrected syntax: assume fileUploadError is the exported name
     generalFileError
   } from '$lib/stores/fileStore.js';
 
@@ -151,7 +150,6 @@
             <span class="item-name file-name">{file.filename}</span>
             <div class="item-actions file-actions">
               <button class="action-btn delete-btn" on:click={() => deleteUploadedFile(file.filename)} title="Delete File">🗑️</button>
-
             </div>
           </li>
         {/each}
@@ -164,7 +162,6 @@
     <div>
       <label class="checkbox-label">
         <input type="checkbox" bind:checked={$longTermMemoryEnabled} on:change={updateSettingsOnServer} />
-
         Enable Long-term Memory
       </label>
     </div>
@@ -190,7 +187,6 @@
 
 <style>
   .sidebar {
-
     width: 300px; /* Increased width slightly */
     padding: 1rem; border-right: 1px solid #e0e0e0; height: 100vh;
     display: flex; flex-direction: column; gap: 1.25rem; /* Increased gap */
@@ -240,7 +236,6 @@
   .file-input:disabled { opacity: 0.7; }
 
   label { display: block; margin-bottom: 0.6rem; font-size: 0.95em; color: #495057; }
-
   .checkbox-label { display: flex; align-items: center; font-size: 0.95em; }
   .checkbox-label input[type="checkbox"] { margin-right: 0.5rem; margin-bottom: 0; }
 

--- a/my-sveltekit-app/svelte.config.js
+++ b/my-sveltekit-app/svelte.config.js
@@ -5,7 +5,11 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 const config = {
   preprocess: vitePreprocess(),
   kit: {
-    adapter: adapter()
+    adapter: adapter(),
+    alias: { // ADD THIS SECTION
+      '$lib': 'src/lib',
+      '$lib/*': 'src/lib/*'
+    }
   }
 };
 

--- a/python_backend/agent_config.py
+++ b/python_backend/agent_config.py
@@ -19,6 +19,8 @@ UI_ACCESSIBLE_WORKSPACE = os.path.join(PROJECT_ROOT, UI_ACCESSIBLE_WORKSPACE_REL
 # Workspace for Code Interpreter (if different) - can be defined later if needed
 # CODE_INTERPRETER_WORKSPACE_RELATIVE = "code_interpreter_ws"
 # CODE_INTERPRETER_WORKSPACE = os.path.join(PROJECT_ROOT, CODE_INTERPRETER_WORKSPACE_RELATIVE)
+
+
 # --- Constants ---
 SUGGESTED_PROMPT_COUNT = 4
 MAX_CHAT_HISTORY_MESSAGES = 20 # Max messages to send to LLM from history

--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -1,5 +1,4 @@
 import uuid
-
 import json
 import asyncio
 import datetime


### PR DESCRIPTION
…un dev`.

Here's what I did:

1.  **Regarding `jsconfig.json` & `svelte.config.js`:**
    *   I removed `compilerOptions.baseUrl` and `compilerOptions.paths` from `jsconfig.json`.
    *   I then added `kit.alias` for `$lib` in `svelte.config.js`, following SvelteKit's recommendations.

2.  **In `Sidebar.svelte`:**
    *   I corrected a JavaScript syntax error within the `<script>` tag.
    *   The line `uploadError: fileUploadError,` seemed to be an incorrect attempt at a named import or object property. I've changed it to `fileUploadError,` assuming it's a named import from a store (like `fileStore.js`).

These adjustments should resolve the SvelteKit build and development server errors related to path aliasing and the syntax in the Sidebar component.