### PR TITLE
Fix(Sidebar): Correct placement of Svelte animate/transition directives

### DIFF
--- a/my-sveltekit-app/src/lib/components/Sidebar.svelte
+++ b/my-sveltekit-app/src/lib/components/Sidebar.svelte
@@ -79,15 +79,18 @@
     {:else}
       <ul class="item-list chat-list">
         {#each $chatHistoryMetadata as chat (chat.chat_id)}
-          <li> <!-- Outer li for list structure, no click handler -->
+          <li
+            title={chat.name} <!-- title on li -->
+            transition:slide|local={{ duration: 200 }} <!-- transition on li -->
+            animate:flip={{ duration: 200 }}         <!-- animate on li -->
+          >
             <button
               type="button"
               class="chat-item-button"
               class:selected={$currentChatId === chat.chat_id}
               on:click={() => handleSelectChat(chat.chat_id)}
-              title={chat.name}
-              transition:slide|local={{ duration: 200 }}
-              animate:flip={{ duration: 200 }}
+              aria-label={chat.name} <!-- aria-label on button for accessibility -->
+              <!-- title={chat.name} removed from button, now on li -->
             >
               <span class="item-name chat-name">{chat.name}</span>
               <div class="item-actions chat-actions">


### PR DESCRIPTION
- Moves `animate:flip` and `transition:slide|local` directives from the inner `<button>` to the parent `<li>` element within the chat list `#each` block in `my-sveltekit-app/src/lib/components/Sidebar.svelte`. This is required by Svelte for these directives to work correctly with keyed lists.
- Adds `aria-label` to the inner button for improved accessibility.

This change should resolve the Svelte error "An element that uses the animate directive must be the immediate child of a keyed each block".