### PR TITLE
Fix(Sidebar): Remove comments from within button tag attributes

### DIFF
--- a/my-sveltekit-app/src/lib/components/Sidebar.svelte
+++ b/my-sveltekit-app/src/lib/components/Sidebar.svelte
@@ -89,8 +89,8 @@
               class="chat-item-button"
               class:selected={$currentChatId === chat.chat_id}
               on:click={() => handleSelectChat(chat.chat_id)}
-              aria-label={chat.name} <!-- aria-label on button for accessibility -->
-              title={chat.name} <!-- title attribute now on button -->
+              aria-label={chat.name}
+              title={chat.name}
             >
               <span class="item-name chat-name">{chat.name}</span>
               <div class="item-actions chat-actions">


### PR DESCRIPTION
Removes HTML comments that were on the same lines as `aria-label` and `title` attributes within the `<button class="chat-item-button">` in `my-sveltekit-app/src/lib/components/Sidebar.svelte`.

These comments were likely confusing the Svelte parser and causing the "Attributes need to be unique" error.